### PR TITLE
Disable variations even when there's only one attribute

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -233,7 +233,9 @@
 					// Get other attributes, if any
 					$other_attrs = $variation_form.find( '.value' ).not(el);
 					if ($other_attrs.length == 0) {
-						return;
+						//Even if there's only one attribute, some variations may be disabled 
+						//through the 'woocommerce_variation_is_active' filter, so we still need to go through all variations..
+						//	return;
 					}
 
 					var other_settings = {};


### PR DESCRIPTION
Recent versions of WooCommerce (since 2.3.0?) has a `woocommerce_variation_is_active` filter which lets you disable ("grey out") e.g. out-of-stock items from the variations dropdown: https://github.com/woothemes/woocommerce/issues/5661

Therefore, to disable the corresponding radiobuttons, the `check_available_attributes` event handler needs to check each variation's `.variation_is_active` property in all cases, not only when there are multiple attributes.