### PR TITLE
Attribute/variation values handling

### DIFF
--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -17,7 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 function print_attribute_radio( $checked_value, $value, $label, $name ) {
 	$checked = checked( sanitize_title( $checked_value ), sanitize_title( $value ), false );
 	$input_name = 'attribute_' . esc_attr( $name ) ;
-	$esc_value = esc_attr( sanitize_title( $value ) );
+	//Needs to be the unaltered attribute value, because it's later compared to that value in add-to-cart-variation.js
+	//	$esc_value = esc_attr( sanitize_title( $value ) );
+	$esc_value = esc_attr( $value );
 	$id = esc_attr( $name . '_v_' . $value );
 	$filtered_label = apply_filters( 'woocommerce_variation_option_name', $label );
 	printf( '<div><input type="radio" name="%1$s" value="%2$s" id="%3$s" %4$s><label for="%3$s">%5$s</label></div>', $input_name, $esc_value, $id, $checked, $filtered_label );


### PR DESCRIPTION
In `add-to-cart-variation.js` (line 291), variations are enabled or disabled by comparing WooCommerce attribute values to what's stored in `<input>` elements' `value="..."`. This means that `sanitize_title()` cannot be used when building `<input>` elements, because `sanitize_title()` changes a string to lowercase and removes special characters.

*This propsed change handles values the same way as WooCommerce's original dropdown (only simple html encoding with `esc_attr()`) - see `wc_dropdown_variation_attribute_options()` in `\woocommerce\includes\wc-template-functions.php`.*

Example: Consider two "Color" variations: "Red & Green" and "Blue & Yellow".

Original WooCommerce dropdown:
```html
<td class="value">
  <select id="color" class="" name="attribute_color" data-attribute_name="attribute_color">
    <option value="">Choose an option</option>
    <option value="Red &amp; Green">Red &amp; Green</option>
    <option value="Blue &amp; Yellow">Blue &amp; Yellow</option>
  </select>
  ...
```

Radio buttons (notice the wrongfully "slugified" `value`s):
```html
<td class="value">
  <div>
    <input type="radio" name="attribute_color" value="red-green" id="color_v_Red &amp; Green" ><label for="color_v_Red &amp; Green">Red & Green</label>
  </div>
  <div>
    <input type="radio" name="attribute_color" value="blue-yellow" id="color_v_Blue &amp; Yellow" ><label for="color_v_Blue &amp; Yellow">Blue & Yellow</label>
  </div>
  ...
```

Radio buttons w/suggested fix:
```html
<td class="value">
  <div>
    <input type="radio" name="attribute_color" value="Red &amp; Green" id="color_v_Red &amp; Green" ><label for="color_v_Red &amp; Green">Red & Green</label>
  </div>
  <div>
    <input type="radio" name="attribute_color" value="Blue &amp; Yellow" id="color_v_Blue &amp; Yellow" ><label for="color_v_Blue &amp; Yellow">Blue & Yellow</label>
  </div>
  ...
```