### PR TITLE
Added product ID to target single products 

### DIFF
--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -22,7 +22,7 @@ if ( ! function_exists( 'print_attribute_radio' ) ) {
 
 		$input_name = 'attribute_' . esc_attr( $name ) ;
 		$esc_value = esc_attr( $value );
-		$id = esc_attr( $name . '_v_' . $value . $product->id ); //added product ID at the end of the name to target single products
+		$id = esc_attr( $name . '_v_' . $value . $product->get_id() ); //added product ID at the end of the name to target single products
 		$filtered_label = apply_filters( 'woocommerce_variation_option_name', $label );
 		printf( '<div><input type="radio" name="%1$s" value="%2$s" id="%3$s" %4$s><label for="%3$s">%5$s</label></div>', $input_name, $esc_value, $id, $checked, $filtered_label );
 	}


### PR DESCRIPTION
I'm using your plugin for displaying variations in archive pages in conjunction with "Woocommerce Add to cart Ajax for variable products" plugin.

I've found a problem when selecting variable atributes in archive pages for different products with same atributes because inputs of different products has the same name in all products, and the javascript wasn't working well (was always targeting the input of the first product).

I solved it adding some customization in your variable.php, in print_attribute_radio function, adding product ids to inputs id names. That way, javascript can properly target the product imputs from every product. Maybe you can update your plugin with a similar modification.