### PR TITLE
include attribute name in filter

### DIFF
--- a/wc-variations-radio-buttons.php
+++ b/wc-variations-radio-buttons.php
@@ -98,7 +98,7 @@ if ( is_plugin_active( 'woocommerce/woocommerce.php') ) {
 			$esc_value = esc_attr( $value );
 			$id = esc_attr( $name . '_v_' . $value . $product->get_id() ); //added product ID at the end of the name to target single products
 			$checked = checked( $checked_value, $value, false );
-			$filtered_label = apply_filters( 'woocommerce_variation_option_name', $label );
+			$filtered_label = apply_filters( 'woocommerce_variation_option_name', $label, esc_attr( $name ) );
 			printf( '<div><input type="radio" name="%1$s" value="%2$s" id="%3$s" %4$s><label for="%3$s">%5$s</label></div>', $input_name, $esc_value, $id, $checked, $filtered_label );
 		}
 	}


### PR DESCRIPTION
Adds the attribute name to the `woocommerce_variation_option_name` filter to give some extra context.