### PR TITLE
Remove 'checked' attribute only from checked fields

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -51,7 +51,7 @@
 	 */
 	VariationForm.prototype.onReset = function( event ) {
 		event.preventDefault();
-		event.data.variationForm.$attributeFields.removeAttr('checked').change();
+		event.data.variationForm.$attributeFields.find(":checked").removeAttr('checked').change();
 		event.data.variationForm.$form.trigger( 'reset_data' );
 	};
 


### PR DESCRIPTION
`VariationForm.prototype.onReset()` removes `checked` attribute and triggers `change` event for all attribute fields, no
matter if those were checked or not. This triggers an unnecessary change event on all attributes. This may impact UI performance (by calling `slideUp()`) if many attributes are present, or cause CSS artifacts as a browser is trashing layout.