### PR TITLE
.removeAttr() is not working, change it to .prop()

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -51,7 +51,7 @@
 	 */
 	VariationForm.prototype.onReset = function( event ) {
 		event.preventDefault();
-		event.data.variationForm.$attributeFields.removeAttr('checked').change();
+		event.data.variationForm.$attributeFields.prop( 'checked', false ).change();
 		event.data.variationForm.$form.trigger( 'reset_data' );
 	};
 


### PR DESCRIPTION
At least since upgrade to WordPress 5.6, hence jQuery 3.5.1, resetting variations button (link) isn't working anymore. Changing .removeAttr( "checked" ) to .prop( "checked", false) fixes the issue.